### PR TITLE
Add universal linking and connection documentation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,26 @@
+# Housing Policy Research Environment Variables
+# Rename this file to `.env` locally and keep it out of version control.
+
+# OpenAI / ChatGPT / Codex
+OPENAI_API_KEY=
+OPENAI_ORG_ID=
+CHATGPT_ARCHIVE_PATH=logs/chatgpt
+
+# Notion
+NOTION_TOKEN=
+NOTION_RESEARCH_DB_ID=
+NOTION_ACTION_ITEMS_DB_ID=
+
+# GitHub
+GITHUB_PAT=
+GITHUB_SSH_KEY_PATH=~/.ssh/id_ed25519
+GITHUB_WEBHOOK_SECRET=
+
+# Zotero
+ZOTERO_API_KEY=
+ZOTERO_LIBRARY_ID=
+ZOTERO_COLLECTION_ID=
+
+# Shared automation settings
+LOG_LEVEL=info
+SYNC_CHECKPOINT_DIR=.sync-state

--- a/README.md
+++ b/README.md
@@ -5,16 +5,17 @@ This repository centralizes documentation, tooling plans, and integration guidel
 ## Quick Start
 
 1. Review the [Environment Integration and Documentation Plan](docs/integration-plan.md) for platform-specific setup steps.
-2. Install the Codex CLI (requires Node.js):
+2. Copy `.env.template` to `.env` and add the required secrets for ChatGPT, Codex, Notion, GitHub, and Zotero.
+3. Install the Codex CLI (requires Node.js):
    ```bash
    npm install -g @openai/codex
    ```
-3. Configure your local `.env` file with scoped tokens for ChatGPT, Notion, GitHub, and Zotero.
 4. Use GitHub Issues or Projects to track automation scripts and data synchronization tasks described in the plan.
+5. For native/web clients, follow the [Universal Linking Guide](docs/universal-linking-guide.md) to keep deep links aligned with repository content.
 
 ## Repository Structure
 
-- `docs/` – Integration architecture, security controls, and task breakdown.
+- `docs/` – Integration architecture, security controls, universal linking guidance, and task breakdown.
 - `SECURITY.md` – Security policy and responsible disclosure instructions.
 - `capstone/` – Structured capstone documentation that replaces the legacy `Capstone alias` export.
 

--- a/docs/connection-checks.md
+++ b/docs/connection-checks.md
@@ -1,0 +1,62 @@
+# Connection & Reverse-Flow Checklists
+
+Use these procedures to confirm that ChatGPT, Codex, Notion, GitHub, and Zotero remain securely linked in both directions. Incorporate the steps into CI jobs or scheduled automations.
+
+## 1. Shared Preparation
+
+1. Copy `.env.template` to `.env` and populate the required tokens.
+2. Run `scripts/connection-checks.sh` (placeholder) or the equivalent automation runner.
+3. Store logs in `logs/connection-checks/YYYY-MM-DD.md` with timestamps and command output.
+
+## 2. Individual Connection Tests
+
+| Integration | Command or API Call | Expected Result | Remediation |
+|-------------|---------------------|-----------------|-------------|
+| ChatGPT API | `curl https://api.openai.com/v1/models -H "Authorization: Bearer $OPENAI_API_KEY"` | HTTP 200 with model list | Rotate key; verify billing status. |
+| Codex CLI | `codex --version` | Prints CLI version | Reinstall CLI or re-export `OPENAI_API_KEY`. |
+| Notion | `python scripts/notion_ping.py` | HTTP 200 from `/v1/databases/{id}` | Confirm database sharing and token scopes. |
+| GitHub | `gh api user` or `curl https://api.github.com/user -H "Authorization: token $GITHUB_PAT"` | Returns authenticated user | Regenerate PAT with `repo` scope or switch to SSH auth. |
+| Zotero | `python scripts/zotero_ping.py` | HTTP 200 with library metadata | Reissue API key; verify library ID. |
+
+## 3. Reverse-Flow Validation
+
+### GitHub → Notion
+
+1. Trigger the documentation sync workflow (GitHub Action `notion-sync.yml`).
+2. Confirm the Notion database reflects the latest commit metadata.
+3. Add a test issue link and ensure the Notion page includes the backlink.
+
+### Notion → Zotero
+
+1. Export a reading list view as JSON using the Notion API.
+2. Run the Zotero sync script to ingest the entries.
+3. Validate that Zotero collections show the new citations with `source=notion` in the extra field.
+
+### Zotero → GitHub
+
+1. Execute `python scripts/zotero_to_github.py --dry-run`.
+2. Inspect the generated markdown in `logs/zotero-exports/`.
+3. Open a PR or issue draft that includes the exported annotations, ensuring sensitive notes are redacted.
+
+### ChatGPT/Codex → GitHub
+
+1. Archive the most recent session transcript into `logs/chatgpt/`.
+2. Run the lint workflow to ensure transcripts contain metadata headers (prompt, timestamp, model).
+3. Reference the archive from the related GitHub issue for traceability.
+
+## 4. Security Controls to Verify
+
+- `.env` file is excluded via `.gitignore`.
+- GitHub Secrets mirror local variable names for CI.
+- Logs omit API keys and personally identifiable information.
+- Key rotation dates are tracked in Notion's security dashboard.
+
+## 5. Reporting
+
+Summarize each run in the Capstone tracker:
+
+1. Status (pass/fail) for every integration and reverse flow.
+2. Action items with owners and deadlines.
+3. Links to GitHub issues raised during the checks.
+
+Maintaining this checklist guarantees that integrations stay aligned with the automation roadmap and security posture described elsewhere in the repository.

--- a/docs/generative-output-tasks.md
+++ b/docs/generative-output-tasks.md
@@ -1,0 +1,51 @@
+# Generative Output Task Breakdown
+
+This runbook expands on Section 9 of `docs/integration-plan.md` and captures the actionable steps required to operationalize generative AI deliverables for the Housing Policy Research initiative.
+
+## 1. Prompt Library
+
+1. Create `docs/prompts/` with subfolders per research theme (e.g., zoning, affordability).
+2. Standardize frontmatter fields: `title`, `objective`, `model`, `temperature`, `reviewer`.
+3. Build a `scripts/prompt_validator.py` utility that lints YAML frontmatter and verifies citations.
+4. Automate publishing to Notion using the Notion sync workflow described in `docs/connection-checks.md`.
+
+## 2. Evaluation Harness
+
+1. Define acceptance criteria in `docs/evaluation-matrix.md` (accuracy, citations, compliance).
+2. Implement scoring scripts:
+   - **Python**: `scripts/evaluate_outputs.py` to parse transcripts/logs and compute metrics.
+   - **Node.js**: optional CLI for integration with Codex prompts.
+3. Store evaluation reports in `reports/generative/` with timestamps.
+4. Gate merges by running the evaluation harness inside GitHub Actions.
+
+## 3. Human-in-the-Loop Reviews
+
+1. Configure a Notion database for reviews with fields: `Output Link`, `Reviewer`, `Status`, `Risks`.
+2. Update GitHub issue templates to include a "Review required" checkbox.
+3. Add an automation that comments on PRs when reviews are overdue, pulling data from Notion.
+4. Document escalation paths in `docs/governance.md`.
+
+## 4. Data Governance
+
+1. Inventory all datasets referenced in prompts and note sensitivity levels.
+2. Tag files in GitHub with `data-classification` labels (e.g., `restricted`, `public`).
+3. Update `.gitattributes` to block large or restricted files from being pushed without approval.
+4. Mirror retention policies in Notion and Zotero notes, referencing ticket IDs for traceability.
+
+## 5. Reporting Automation
+
+1. Combine GitHub issue metrics, Notion task status, and Zotero citation counts via scheduled workflows.
+2. Generate a weekly markdown brief in `reports/status/` and post a summary to Notion.
+3. Provide universal links (see `docs/universal-linking-guide.md`) in the brief so mobile users can open sections directly.
+4. Archive the generated briefs via ChatGPT/Codex logging to maintain provenance.
+
+## 6. Implementation Tracker
+
+Use GitHub Projects or Issues to track the above workstreams. For each item, include:
+
+- Definition of done.
+- Owner and due date.
+- Linked automation scripts and datasets.
+- Security review checklist reference.
+
+Following this breakdown keeps the generative AI roadmap transparent and tightly integrated with the repository's security and automation controls.

--- a/docs/integration-plan.md
+++ b/docs/integration-plan.md
@@ -91,9 +91,9 @@ Automate each pipeline with CI jobs or scheduled tasks that authenticate using s
 
 ### Verification Steps for Secure Connections
 
-1. **Credential Audit** – Confirm each platform token (ChatGPT, Codex CLI, Notion, GitHub, Zotero) is present in both the local `.env` file and the GitHub Secrets store with matching scopes.
-2. **Connection Tests** – Run a dry-run command or API call for every integration, capturing success logs in the repository (e.g., `logs/connection-checks/`).
-3. **Reverse Flow Validation** – Execute the reverse synchronization paths (GitHub→Notion, Notion→Zotero, Zotero→GitHub) in a staging environment and review audit logs for unauthorized access attempts.
+1. **Credential Audit** – Confirm each platform token (ChatGPT, Codex CLI, Notion, GitHub, Zotero) is present in both the local `.env` file (generated from `.env.template`) and the GitHub Secrets store with matching scopes.
+2. **Connection Tests** – Follow the commands listed in [`docs/connection-checks.md`](docs/connection-checks.md) and capture success logs in `logs/connection-checks/`.
+3. **Reverse Flow Validation** – Execute the reverse synchronization paths (GitHub→Notion, Notion→Zotero, Zotero→GitHub, ChatGPT/Codex→GitHub) using the same checklist.
 4. **Security Review** – Verify that logs exclude sensitive payloads, rotate tokens post-test, and document findings in the capstone tracker within `capstone/`.
 
 ## 5. Security Controls
@@ -140,7 +140,7 @@ Automate each pipeline with CI jobs or scheduled tasks that authenticate using s
 
 ## 9. Generative Output Roadmap
 
-To coordinate automation and AI-assisted deliverables, track the following workstreams in GitHub Projects and reference them from the `capstone/` documentation:
+For the actionable steps, see [`docs/generative-output-tasks.md`](docs/generative-output-tasks.md). Track the summarized workstreams in GitHub Projects and reference them from the `capstone/` documentation:
 
 1. **Prompt Library** – Curate reusable ChatGPT and Codex prompts aligned to housing policy research goals; version them in `docs/prompts/`.
 2. **Evaluation Harness** – Implement scripts that score generative outputs against acceptance criteria (accuracy, citation coverage, compliance).

--- a/docs/universal-linking-guide.md
+++ b/docs/universal-linking-guide.md
@@ -1,0 +1,80 @@
+# Universal Linking Guide for Housing Policy Research Apps
+
+This guide summarizes Apple's [Allowing apps and websites to link to your content](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content/) reference and adapts it to the Housing Policy Research automations. Use it when shipping native or web clients that deep-link into Notion hubs, GitHub issues, or custom dashboards.
+
+## 1. Goals
+
+- Provide a single, secure user experience between the web portal and any iOS/iPadOS/macOS companion apps.
+- Ensure documentation, prompts, and Zotero references opened from ChatGPT/Codex automations land on the correct in-app screen.
+- Maintain audit trails by routing universal link events through the same logging stack described in `docs/integration-plan.md`.
+
+## 2. Prerequisites
+
+1. An iOS, iPadOS, or macOS app with the Associated Domains capability enabled.
+2. Access to the GitHub Pages (or other HTTPS) host that will serve the `apple-app-site-association` (AASA) file.
+3. App identifiers for production and staging bundles (e.g., `com.envixronment.housingpolicy.dev`).
+4. SSL certificates that do not require redirects (AASA requests must return HTTP 200 over HTTPS).
+
+## 3. Configure Associated Domains
+
+1. In Xcode, open the project target and enable **Signing & Capabilities → Associated Domains**.
+2. Add entries for each environment:
+   - `applinks:envixronment.example.com`
+   - `applinks:staging.envixronment.example.com`
+3. Commit the updated `.entitlements` file to the repo that houses the native app. Reference this document from the PR description so reviewers can validate the changes.
+
+## 4. Author the `apple-app-site-association` File
+
+Create a JSON file without an extension named `apple-app-site-association` at the HTTPS root (or under `./well-known/`). Example snippet:
+
+```json
+{
+  "applinks": {
+    "details": [
+      {
+        "appID": "ABCDE12345.com.envixronment.housingpolicy",
+        "paths": [
+          "/docs/*",
+          "/capstone/*",
+          "/notion-sync/*"
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Operational tips**
+- Host the file in this Git repository if you are serving docs through GitHub Pages. Add a workflow that lints JSON and deploys to Pages to avoid manual drift.
+- Use separate entries for staging vs. production bundle IDs and domains.
+- Keep the list of `paths` tight; anything not listed falls back to opening in Safari.
+
+## 5. Map Paths to Automation Targets
+
+Align universal link paths with existing automations:
+
+| Path Prefix | Destination | Notes |
+|-------------|-------------|-------|
+| `/docs/prompts/` | Markdown prompt library in GitHub | Enables ChatGPT or Codex output links to open directly in-app. |
+| `/notion-sync/` | Notion database entries surfaced via the native app | Mirror Notion record IDs so review tasks open in context. |
+| `/zotero/` | Zotero reading queue and annotations | Provide read-only previews inside the app with a CTA to open Zotero proper. |
+
+For reverse flows (e.g., GitHub → Notion), include a `?source=` query value so automation logs can attribute the event.
+
+## 6. Testing & Validation
+
+1. **Simulator Test** – Install the app via Xcode, run `xcrun simctl openurl booted https://envixronment.example.com/docs/prompts/123` and confirm the in-app view loads.
+2. **Device Test** – Use TestFlight or Ad Hoc builds to validate universal links on actual hardware.
+3. **Automation Test** – Extend the existing connection-check scripts (see `docs/connection-checks.md`) to fetch the AASA file and verify that:
+   - The JSON is valid.
+   - The required bundle IDs are present.
+   - Paths align with current repos/Notion/Zotero identifiers.
+4. **Logging** – Emit a structured log whenever the app handles a universal link, including the `source` query parameter and authenticated user ID.
+
+## 7. Maintenance
+
+- Review AASA entries quarterly when rotating API tokens and access (aligns with the security cadence in `docs/integration-plan.md`).
+- Update this guide whenever new modules (e.g., a new Notion database) require deep links.
+- Store archived versions of the AASA file to aid in regression debugging.
+
+Following these steps keeps the mobile/web experience aligned with the broader automation and documentation workflow already in the repository.


### PR DESCRIPTION
## Summary
- add a checked-in `.env.template` and update the README so contributors can configure secrets consistently
- document universal linking requirements plus detailed connection and reverse-flow validation procedures
- expand the integration plan with references to the new runbooks and provide a concrete generative-output task breakdown

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d2edf23ec83319f1a53b742e94d6c)