### PR TITLE
Fix git add path in cross-chat sync commit flow

### DIFF
--- a/scripts/cross-chat-sync.sh
+++ b/scripts/cross-chat-sync.sh
@@ -36,7 +36,8 @@ fi
 if [[ "${1-}" == "--commit" ]]; then
   if git -C "$TARGET_DIR/.." rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     REPO_DIR="$(cd "$TARGET_DIR/.." && pwd)"
-    git -C "$REPO_DIR" add indexes
+    # Add CSVs relative to the repo root (avoids duplicating the Capstone path)
+    git -C "$REPO_DIR" add "indexes"/*.csv
     git -C "$REPO_DIR" commit -m "chore(indexes): update cross-chat CSVs $(date +"%Y-%m-%d %H:%M:%S")"
     echo "Committed to Git repo at $REPO_DIR"
   else


### PR DESCRIPTION
## Summary
- fix the git add path in the cross-chat sync script so it targets the indexes directory relative to the Capstone repo

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692354fee144833195e09edeac60b55a)