### PR TITLE
Add repository rulesets documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This repository hosts documentation and tooling for collaborative research on ho
 
 1. Clone the repository and create a local development environment (see [Environment Setup](docs/environment-setup.md)).
 2. Review the [Project Roadmap](docs/project-roadmap.md) for outstanding tasks.
-3. Use GitHub issues to track progress and link commits to roadmap items.
+3. Read the [Repository Rulesets and Integration Controls](docs/rulesets.md) for security and connectivity requirements.
+4. Use GitHub issues to track progress and link commits to roadmap items.
 
 ## Tooling Overview
 

--- a/docs/rulesets.md
+++ b/docs/rulesets.md
@@ -1,0 +1,70 @@
+# Repository Rulesets and Integration Controls
+
+This ruleset consolidates security, connectivity, and documentation expectations for the Housing Policy Research environment. It applies to all workstreams that rely on ChatGPT/Codex, Notion, GitHub, and Zotero.
+
+## Core Principles
+
+- **Security first**: Secrets stay out of version control and are stored in encrypted managers or GitHub Secrets.
+- **Traceability**: Every automated sync must write minimal, non-sensitive logs for auditing.
+- **Reproducibility**: Document configuration steps, validation results, and failure modes alongside the code that depends on them.
+- **Least privilege**: Tokens and integrations must use the smallest scopes that support the workflow.
+- **Dual flows**: Forward and reverse data paths (e.g., GitHub→Notion and Notion→GitHub) require mirrored validation checks.
+
+## Platform Rules
+
+### ChatGPT / Codex
+- API keys are exported as `OPENAI_API_KEY` only in local shells or CI environments; never hard-code keys in scripts.
+- CLI usage (`codex ...`) must be wrapped with rate-limit handling and time-stamped logs saved under `logs/`.
+- Model prompts and outputs that influence research deliverables are archived in versioned Markdown (`docs/prompts/` and `docs/outputs/`).
+- Reverse connection: When ChatGPT generates content that is committed to GitHub, record the prompt, model version, and reviewer in the commit description or linked issue.
+
+### Notion
+- Integration tokens are stored as `NOTION_API_KEY` and granted access only to required databases/pages.
+- Database IDs used by scripts belong in `.env` (ignored by Git) or GitHub Secrets; document friendly names in `docs/notion-mapping.md`.
+- Sync scripts must log the Notion page IDs touched, the source file, and the timestamp. Logs cannot include raw content.
+- Reverse connection: Changes pulled from Notion into GitHub require a reviewer to confirm formatting and data classification before merging.
+
+### GitHub
+- Enable branch protection for default branches and require reviews for automation-generated pull requests.
+- Use deploy keys or fine-scoped PATs for automation; avoid reusing human credentials in CI.
+- Store all secret variables in `Settings → Secrets and variables → Actions`; mirror the names used in local `.env` files.
+- Reverse connection: When external systems (Notion, Zotero, ChatGPT) push updates, the corresponding workflows must open pull requests rather than direct pushes.
+
+### Zotero
+- API keys live in `ZOTERO_API_KEY`; library IDs are stored separately (e.g., `ZOTERO_LIBRARY_ID`).
+- Scripts must respect rate limits and include retry logic with exponential backoff.
+- Exported bibliographies belong in `docs/references/` with dates and source library references.
+- Reverse connection: GitHub→Zotero writes should be staged (dry-run first) and logged with item keys and collection names.
+
+## Documentation and Error Handling
+
+- Update `docs/environment-setup.md` and `docs/integration-plan.md` whenever new credentials, scopes, or workflows are introduced.
+- Log connection checks in `logs/connection-checks/` (create if missing) with timestamps and anonymized results.
+- Any script failure must capture: platform, endpoint, HTTP status/error code, retry count, and whether secrets were rotated.
+- Replace corrupted or duplicated documentation assets; keep a pointer to the authoritative source (GitHub for code/docs, Zotero for citations, Notion for meeting notes).
+
+## Validation Rules
+
+Run these checks after configuration changes or quarterly:
+1. **Credential audit** – Confirm `.env` and GitHub Secrets contain aligned keys for ChatGPT, Codex CLI, Notion, GitHub automation, and Zotero.
+2. **Forward flow tests** – GitHub→Notion, GitHub→Zotero, and ChatGPT→GitHub scripts run without errors and log success entries.
+3. **Reverse flow tests** – Notion→GitHub and Zotero→GitHub syncs execute in a staging branch and open pull requests with reviewers assigned.
+4. **Access review** – Verify tokens remain scoped to intended resources; revoke unused credentials and rotate active keys.
+5. **Log hygiene** – Ensure logs omit secrets and sensitive personal data; archive quarterly summaries in `docs/audit-notes/`.
+
+## Generative Output Governance
+
+- Maintain acceptance criteria for AI-generated content (accuracy, citation coverage, tone) in `docs/prompts/README.md`.
+- All generative outputs must include provenance metadata: prompt ID, model, date, reviewer, and verification status.
+- High-risk outputs (policy recommendations, legal drafts) require human review and sign-off before publication.
+- Store evaluation results from scoring harnesses in `docs/outputs/evaluations/` and link them to issues or pull requests.
+
+## Task Breakdown and Next Steps
+
+1. **Create secret templates** – Add `.env.template` entries for OpenAI, Notion, GitHub, and Zotero keys; include comments on required scopes.
+2. **Stand up logging folders** – Add `logs/connection-checks/` with a sample log format; ensure `.gitignore` permits committed, redacted logs.
+3. **Document reverse syncs** – Write minimal runbooks for Notion→GitHub and Zotero→GitHub pipelines (staging branch usage, dry-run steps).
+4. **Add validation scripts** – Implement smoke tests that hit each API with a dry-run and write structured results to `logs/connection-checks/`.
+5. **Set review policy** – Configure branch protection and PR templates that require reviewers for automation-originated changes.
+
+Track completion of these items in GitHub issues or the project roadmap, linking back to this ruleset for traceability.


### PR DESCRIPTION
## Summary
- add repository-wide rulesets covering security, connection, and governance requirements for ChatGPT/Codex, Notion, GitHub, and Zotero
- document validation rules, error handling expectations, and next-step tasks for integrations
- link the new ruleset from the README getting started section

## Testing
- not run (documentation updates only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9a95db1c8331ae5c21aaa1f0388a)

## Summary by Sourcery

Document repository-wide security, connectivity, and governance rules for core integrations and surface them in the getting started flow.

Documentation:
- Add a comprehensive rulesets document outlining security, connectivity, validation, and governance requirements for ChatGPT/Codex, Notion, GitHub, and Zotero integrations.
- Update the README getting-started steps to reference the new repository rulesets and integration controls document.