### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -14,6 +14,8 @@ on:
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read
 jobs:
   # This workflow contains a single job called "build"
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/SfosssHousing/HousingPolicyResearch/security/code-scanning/1](https://github.com/SfosssHousing/HousingPolicyResearch/security/code-scanning/1)

To fix the problem, you should explicitly set the permissions in your GitHub Actions workflow to the minimal privileges required by the workflow's jobs. As a general starting point for CI workflows, this usually means adding a `permissions:` block with `contents: read` at the root level, before the `jobs:` key. This ensures that the injected `GITHUB_TOKEN` only has read access to repository contents, adhering to the principle of least privilege. No imports, external dependencies, or functional code changes are required—this is a YAML configuration fix. The change should be made near the top level of your `.github/workflows/blank.yml` file, before the `jobs:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
