### PR TITLE
Fix: Correct verification document line counts to match actual files

### DIFF
--- a/docs/agent-instructions-verification.md
+++ b/docs/agent-instructions-verification.md
@@ -1,7 +1,7 @@
 # Agent Instructions Verification Report
 
-**Date:** 2025-12-02  
-**Issue:** Agent instructions @copilot  
+**Date:** 2025-12-02\
+**Issue:** Agent instructions @copilot\
 **Status:** ✅ VERIFIED AND OPERATIONAL
 
 ## Executive Summary
@@ -11,8 +11,9 @@ All GitHub Copilot agent instructions and configurations have been verified and 
 ## Verification Checklist
 
 ### ✅ GitHub Copilot Instructions
+
 - **Location:** `.github/copilot-instructions.md`
-- **Status:** Present and comprehensive (211 lines)
+- **Status:** Present and comprehensive (51 lines)
 - **Last Updated:** 2025-12-02
 - **Coverage:**
   - Project overview and technology stack
@@ -25,19 +26,22 @@ All GitHub Copilot agent instructions and configurations have been verified and 
   - Anti-patterns and best practices
 
 ### ✅ Custom Agent Configuration
+
 - **Location:** `.github/agents/my-agent.agent.md`
 - **Name:** housing-research
 - **Description:** Curates, cites, and maintains a policy resources database
-- **Tools:** read, search, edit, github/*
+- **Tools:** read, search, edit, github/\*
 - **Target:** github-copilot
 - **Mission:** Build and maintain rigorous Resources Database with accurate citations
 
 ### ✅ Supporting Infrastructure
+
 All referenced documentation exists and is operational:
-- `/docs/STYLE-APA.md` - APA 7th edition citation standards (287 lines)
-- `/docs/resources-index.md` - Comprehensive catalog (424 lines, 21 resources)
+
+- `/docs/STYLE-APA.md` - APA 7th edition citation standards (335 lines)
+- `/docs/resources-index.md` - Comprehensive catalog (457 lines, 21 resources)
 - `/docs/resources.csv` - Machine-readable database (22 rows)
-- `/docs/generative-output-version-control.md` - AI content tracking (420 lines)
+- `/docs/generative-output-version-control.md` - AI content tracking (465 lines)
 - `/docs/environment-setup.md` - Environment configuration guide
 - `/docs/integration-plan.md` - API integration architecture
 - `/docs/project-roadmap.md` - Project planning and tasks
@@ -46,6 +50,7 @@ All referenced documentation exists and is operational:
 ## Key Features Verified
 
 ### 1. Citation Management
+
 - APA 7th edition standards strictly enforced
 - DOI preference and persistent identifiers
 - Complete metadata requirements
@@ -53,6 +58,7 @@ All referenced documentation exists and is operational:
 - Quality flags and access status indicators
 
 ### 2. Security Practices
+
 - No credentials committed (verified)
 - Environment variable template present (`.env.template`)
 - Security policy documented (`SECURITY.md`)
@@ -60,6 +66,7 @@ All referenced documentation exists and is operational:
 - Least-privilege access principles
 
 ### 3. Resource Database
+
 - 21 resources cataloged and annotated
 - Full APA citations with DOIs/URLs
 - Cross-references to documentation
@@ -67,6 +74,7 @@ All referenced documentation exists and is operational:
 - 100% link verification as of 2025-12-02
 
 ### 4. Custom Agent Capabilities
+
 - Automated resource indexing
 - APA-style citation generation
 - Quality gate enforcement
@@ -77,20 +85,21 @@ All referenced documentation exists and is operational:
 
 ## Compliance Assessment
 
-| Requirement | Status | Notes |
-|-------------|--------|-------|
-| Copilot instructions file exists | ✅ | Comprehensive 211-line guide |
-| Custom agent configured | ✅ | Housing research librarian agent |
-| APA citation standards documented | ✅ | 287-line style guide with examples |
-| Resource database operational | ✅ | 21 resources indexed and verified |
-| Security practices documented | ✅ | No secrets in repo, templates present |
-| Contributing guidelines present | ✅ | Clear workflow and PR requirements |
-| Documentation cross-linked | ✅ | All internal links validated |
-| Machine-readable formats | ✅ | CSV database ready for automation |
+| Requirement                       | Status | Notes                                 |
+| --------------------------------- | ------ | ------------------------------------- |
+| Copilot instructions file exists  | ✅     | Comprehensive 51-line guide          |
+| Custom agent configured           | ✅     | Housing research librarian agent      |
+| APA citation standards documented | ✅     | 335-line style guide with examples    |
+| Resource database operational     | ✅     | 21 resources indexed and verified     |
+| Security practices documented     | ✅     | No secrets in repo, templates present |
+| Contributing guidelines present   | ✅     | Clear workflow and PR requirements    |
+| Documentation cross-linked        | ✅     | All internal links validated          |
+| Machine-readable formats          | ✅     | CSV database ready for automation     |
 
 ## Agent Instruction Quality Metrics
 
 ### Copilot Instructions Coverage
+
 - ✅ Project overview and context
 - ✅ Repository structure explanation
 - ✅ Technology stack documentation
@@ -103,6 +112,7 @@ All referenced documentation exists and is operational:
 - ✅ Support channels and resources
 
 ### Custom Agent Specification
+
 - ✅ Clear mission statement
 - ✅ Defined responsibilities
 - ✅ Quality guardrails
@@ -116,15 +126,17 @@ All referenced documentation exists and is operational:
 The agent instructions align with and reinforce existing repository patterns:
 
 1. **Evidence-based research:** Citation standards support rigorous policy analysis
-2. **Reproducible workflows:** Documentation enables consistent processes
-3. **Secure integrations:** API guidelines protect credentials
-4. **Version control:** Git patterns for all documentation changes
-5. **Automation-ready:** Machine-readable formats enable tooling
+1. **Reproducible workflows:** Documentation enables consistent processes
+1. **Secure integrations:** API guidelines protect credentials
+1. **Version control:** Git patterns for all documentation changes
+1. **Automation-ready:** Machine-readable formats enable tooling
 
 ## Recommendations
 
 ### Current State: EXCELLENT ✅
+
 No immediate actions required. All agent instructions are:
+
 - Properly configured
 - Comprehensive in coverage
 - Aligned with repository goals
@@ -132,13 +144,15 @@ No immediate actions required. All agent instructions are:
 - Ready for ongoing operations
 
 ### Optional Future Enhancements
+
 1. Add workflow automation for link checking
-2. Implement automated citation validation
-3. Create GitHub Actions for CSV validation
-4. Add changelog automation for resource updates
-5. Implement automated quarterly review reminders
+1. Implement automated citation validation
+1. Create GitHub Actions for CSV validation
+1. Add changelog automation for resource updates
+1. Implement automated quarterly review reminders
 
 ### Maintenance Schedule
+
 - **Quarterly reviews:** Update agent instructions if repository patterns evolve
 - **Version tracking:** Maintain version numbers in instruction files
 - **Feedback integration:** Incorporate lessons learned from agent usage
@@ -149,6 +163,7 @@ No immediate actions required. All agent instructions are:
 **VERIFICATION COMPLETE: ✅ PASS**
 
 All GitHub Copilot agent instructions are properly configured, comprehensive, and operational. The repository has:
+
 - Clear instructions for general Copilot usage
 - Specialized custom agent for housing research tasks
 - Complete supporting documentation infrastructure
@@ -157,9 +172,9 @@ All GitHub Copilot agent instructions are properly configured, comprehensive, an
 
 No corrective actions are required. The agent instructions meet all requirements for collaborative housing policy research with rigorous citation standards and secure API integrations.
 
----
+______________________________________________________________________
 
-**Verified by:** GitHub Copilot Agent  
-**Verification Date:** 2025-12-02  
-**Next Review:** 2025-03-02 (quarterly maintenance)  
+**Verified by:** GitHub Copilot Agent\
+**Verification Date:** 2025-12-02\
+**Next Review:** 2025-03-02 (quarterly maintenance)\
 **Status:** Operational and ready for use


### PR DESCRIPTION
## Summary

This PR corrects inaccurate line counts in the agent instructions verification report that were flagged during PR #30 review and tracked in issues #34 and #73.

### Changes

Corrected line counts in `/docs/agent-instructions-verification.md` to match actual file lengths:

| File | Previously Stated | Actual | Status |
|------|------------------|--------|--------|
| `.github/copilot-instructions.md` | 211 lines | 51 lines | ✅ Fixed |
| `STYLE-APA.md` | 287 lines | 335 lines | ✅ Fixed |
| `resources-index.md` | 424 lines | 457 lines | ✅ Fixed |
| `generative-output-version-control.md` | 420 lines | 465 lines | ✅ Fixed |
| `resources.csv` | (unchanged) | 22 rows | ✅ Verified |

### Motivation

The verification document contained inaccurate documentation metrics, which undermined the credibility of the "verified and operational" assessment. These corrections ensure the audit report accurately reflects the actual state of the repository's documentation infrastructure.

### Relates To

Fixes issues identified in:
- PR #30 review comments
- Issue #34: Copilot review error tracking
- Issue #73: Coordination of corrections across sessions

### Testing

✅ Verified all line counts with `wc -l` commands
✅ Confirmed fixes align with PR #30 review requirements
✅ Updated compliance assessment table to reflect corrections